### PR TITLE
Vagrant list provisions on `--provision-with`

### DIFF
--- a/vagrant.lua
+++ b/vagrant.lua
@@ -26,15 +26,14 @@ end
 
 local function get_vagrantfile()
     local vagrant_cwd = clink.get_env("VAGRANT_CWD")
-    local vagrant_file = nil
-    if not is_empty(vagrant_cwd) then 
-        return find_vagrantfile(vagrant_cwd) 
-    else 
+    if not is_empty(vagrant_cwd) then
+        return find_vagrantfile(vagrant_cwd)
+    else
         return find_vagrantfile()
     end
 end
 
-function delete_ruby_comment(line)
+local function delete_ruby_comment(line)
   if line == nil then return nil end
     local index = string.find(line, '#')
     if (not (index == nil) and index > 0) then
@@ -43,7 +42,7 @@ function delete_ruby_comment(line)
   return line
 end
 
-local get_provisions = function (token)
+local get_provisions = function ()
     local vagrant_file = get_vagrantfile()
     if vagrant_file == nil then return {} end
 


### PR DESCRIPTION
This PR provides used provision names from Vagrantfile if possible.

I use this regex for each line in `Vagrantfile`:
`.vm.provision[ \r\t]+\"([A-z]+[A-z0-9]*)\"`
It can sometimes provide some names which are not taken into consideration by the vagrant, but I don't want to parse ruby. This solution is simple and in my opinion sufficient.

Tests:
* [x] analyse not commented lines in Vagrantfile (cut comment)
* [x] use any whitespace between provision name and configuration (lua fails with  `\s+`)
* check environment
   * [x] file name (VAGRANT_VAGRANTFILE)
   * [x] folder name (VAGRANT_CWD)

[How to find Vagrantfile](https://www.vagrantup.com/docs/vagrantfile/)
[Vagrant env variables](https://www.vagrantup.com/docs/other/environmental-variables.html)